### PR TITLE
use mpi instead of mpi_f08

### DIFF
--- a/mpi_wrapper.F90
+++ b/mpi_wrapper.F90
@@ -1,6 +1,6 @@
 module mpi_wrapper
 
-   use mpi_f08
+   use mpi
 
    implicit none
 
@@ -14,7 +14,7 @@ module mpi_wrapper
    integer, save :: mype = -999
    integer, save :: npes = -999
    integer, save :: root = -999
-   type(MPI_Comm), save :: comm
+   integer, save :: comm
    logical, save :: initialized = .false.
 
    integer :: ierror
@@ -79,7 +79,7 @@ contains
 
    subroutine mpi_wrapper_initialize(mpiroot, mpicomm)
       integer, intent(in) :: mpiroot
-      type(MPI_Comm), intent(in) :: mpicomm
+      integer, intent(in) :: mpicomm
       if (initialized) return
       root = mpiroot
       comm = mpicomm
@@ -93,7 +93,7 @@ contains
       mype = -999
       npes = -999
       root = -999
-      comm%mpi_val = -999
+      comm = -999
       initialized = .false.
    end subroutine mpi_wrapper_finalize
 

--- a/stochastic_physics.F90
+++ b/stochastic_physics.F90
@@ -4,7 +4,7 @@
 !>@brief The module 'stochastic_physics' is for initialization and running of
 !! the stochastic physics random pattern generators
 module stochastic_physics
-use mpi_f08
+use mpi
 use kinddef, only : kind_phys, kind_dbl_prec
 use mpas_pool_routines
 
@@ -39,7 +39,7 @@ implicit none
 
 type(domain_type),intent(inout)     :: domain
 integer,              intent(in)    :: levs, mpiroot
-type(MPI_Comm),       intent(in)    :: mpicomm
+integer,              intent(in)    :: mpicomm
 integer,              intent(in)    :: blksz(:)
 real(kind=kind_phys), intent(in)    :: dtp
 real(kind=kind_phys), intent(out)   :: sppt_amp

--- a/stochastic_physics_mpas.F
+++ b/stochastic_physics_mpas.F
@@ -1,6 +1,6 @@
 module mpas_stochastic_physics
   use kinddef, only: kind_phys
-  use mpi_f08
+  use mpi
   use mpas_pool_routines
   implicit none
 
@@ -86,7 +86,7 @@ module mpas_stochastic_physics
 !local variables:
     type(block_type),pointer:: block
     integer :: maxblk, blk_sz(16)
-    type(MPI_comm) ::  mpi_comm
+    integer ::  mpi_comm
     integer :: mpi_root, pid
     integer :: iret
     real(kind=kind_phys):: sppt_amp, dtp


### PR DESCRIPTION
This PR is needed by PR https://github.com/dtcenter/MPAS-Model/pull/3


In the future, we can introduce `#ifdef MPAS_USE_MPI_F08` to make it flexible for both `mpi` and `mpi_f08` situations