### PR TITLE
Adjustments to kinds to get stochastic_physics to build with MPAS-Model.

### DIFF
--- a/kinddef.F90
+++ b/kinddef.F90
@@ -1,6 +1,6 @@
 module kinddef
 #ifdef MPAS
-  use mpas_kind_types, only: R4KIND, R8KIND, I8KIND, StrKIND
+  use mpas_kind_types, only: R4KIND, R8KIND, RKIND, I8KIND, StrKIND
 #endif
   
   implicit none
@@ -10,6 +10,7 @@ module kinddef
   public :: kind_phys
   public :: kind_dbl_prec, kind_qdt_prec
   public :: kind_io8
+  public :: RKIND, StrKIND
 
   ! FV3
 #ifdef FV3
@@ -24,13 +25,13 @@ module kinddef
   
   ! MPAS
 #ifdef MPAS
-  integer, parameter :: kind_dbl_prec => R8KIND
+  integer, parameter :: kind_dbl_prec = R8KIND
 #ifdef CCPP_32BIT
-  integer, parameter :: kind_phys     => R4KIND
+  integer, parameter :: kind_phys     = R4KIND
 #else
-  integer, parameter :: kind_phys     => R8KIND
+  integer, parameter :: kind_phys     = R8KIND
 #endif
-  integer, parameter :: kind_io8      => I8KIND
+  integer, parameter :: kind_io8      = I8KIND
 #endif
 
 #ifdef NO_QUAD_PRECISION

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -31,7 +31,7 @@ module mpas_stochastic_physics
 !  integer, dimension(:,:),   allocatable, save :: stype
 
   logical, pointer :: do_sppt_config, do_skeb_config, do_shum_config, do_spp_config 
-  logical :: do_sppt = .true. 
+  logical :: do_sppt = .true.
   logical :: do_skeb, do_shum, do_spp 
 
   real(kind=RKIND), dimension(:),pointer:: lonCell, latCell
@@ -154,10 +154,6 @@ module mpas_stochastic_physics
       call mpas_pool_get_subpool(block%structs,'tend_physics' ,tend_physics)
       call mpas_pool_get_array(tend_physics,'stoch_pattern_sppt',stoch_pat_sppt)
       call mpas_pool_get_array(tend_physics,'stoch_pattern_gg',stoch_pat_gg)
-      ! In the following, is the real() explicit type conversion necessary?
-      ! Fortran should automatically perform implicit type conversion from 
-      ! integer (which is the type of my_proc_id) to whatever the type of
-      ! stoch_pat_sppt is.
       stoch_pat_sppt(:,:) = real(domain%dminfo%my_proc_id, kind=RKIND)
       block => block%next
     enddo
@@ -182,14 +178,14 @@ module mpas_stochastic_physics
       call mpas_pool_get_array(mesh,'lonCell',lonCell)
       call mpas_pool_get_array(mesh,'latCell',latCell)
       call mpas_pool_get_dimension(mesh,'nCells',nCells)
-      xlon(nblks,1:nCells) = lonCell(1:nCells) 
-      xlat(nblks,1:nCells) = latCell(1:nCells) 
+      xlon(nblks,1:nCells) = real(lonCell(1:nCells), kind=kind_phys)
+      xlat(nblks,1:nCells) = real(latCell(1:nCells), kind=kind_phys)
       block => block%next
     enddo
 
 !    if (pid == 0) print*, 'Call init_stochastic_physics (domain, ...).'
     mpi_root = 0; mpi_comm = domain%dminfo%comm
-    dtp = dt
+    dtp = real(dt, kind=kind_phys)
     ierr = 0
     call init_stochastic_physics(domain, nVertLevels, blksz, dtp, sppt_amp, &
          xlon, xlat, zk, mpi_comm, mpi_root, iret) 
@@ -266,9 +262,7 @@ module mpas_stochastic_physics
 !    call run_stochastic_physics(nVertLevels, ts_ct, blksz, st_pat, stoch_pat_gg, iret)
     if (iret == 0) then ! if pattern is advanced (updated)
       do k = 1, nVertLevels
-        ! The following will involve an implicit type (actually, kind) conversion
-        ! if RKIND and kind_phys are not equivalent.
-        stoch_pat_sppt(k,1:nCells) = st_pat(1,1:nCells,k)
+        stoch_pat_sppt(k,1:nCells) = real(st_pat(1,1:nCells,k), kind=RKIND)
       enddo
     endif
     deallocate(st_pat)

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -1,5 +1,5 @@
 module mpas_stochastic_physics
-  use kinddef, only: kind_phys
+  use kinddef, only: kind_phys, RKIND
   use mpi_f08
   use mpas_pool_routines
   use mpas_log, only : mpas_log_write, mpas_log_info
@@ -34,16 +34,16 @@ module mpas_stochastic_physics
   logical :: do_sppt = .true. 
   logical :: do_skeb, do_shum, do_spp 
 
-  real(kind=kind_phys), dimension(:),pointer:: lonCell, latCell
-  real(kind=kind_phys), dimension(:,:),pointer:: stoch_pat_sppt  ! stoch(nVertLevels, nCells)
-  real(kind=kind_phys), dimension(:,:),pointer:: zgrid  ! zgrid(nVertLevelsP1, nCells)
-  real(kind=kind_phys), dimension(:,:),pointer:: stoch_pat_gg  ! stoch(log_for, lat_leg)
+  real(kind=RKIND), dimension(:),pointer:: lonCell, latCell
+  real(kind=RKIND), dimension(:,:),pointer:: stoch_pat_sppt  ! stoch(nVertLevels, nCells)
+  real(kind=RKIND), dimension(:,:),pointer:: zgrid  ! zgrid(nVertLevelsP1, nCells)
+  real(kind=RKIND), dimension(:,:),pointer:: stoch_pat_gg  ! stoch(lon_for, lat_leg)
   integer, dimension(:), pointer :: blksz
   integer, pointer :: nCells, nEdges, nVertLevels, nVertLevelsP1
   integer, pointer :: lon_f, lat_g
-  real(kind=kind_phys), pointer :: dt, sppt_1, sppt_2, sppt_3
-  real(kind=kind_phys), pointer :: sppt_tau_1, sppt_tau_2, sppt_tau_3 
-  real(kind=kind_phys), pointer :: sppt_lscale_1, sppt_lscale_2, sppt_lscale_3 
+  real(kind=RKIND), pointer :: dt, sppt_1, sppt_2, sppt_3
+  real(kind=RKIND), pointer :: sppt_tau_1, sppt_tau_2, sppt_tau_3
+  real(kind=RKIND), pointer :: sppt_lscale_1, sppt_lscale_2, sppt_lscale_3
   integer, pointer :: spptint
 
   integer, save :: nblks
@@ -154,7 +154,11 @@ module mpas_stochastic_physics
       call mpas_pool_get_subpool(block%structs,'tend_physics' ,tend_physics)
       call mpas_pool_get_array(tend_physics,'stoch_pattern_sppt',stoch_pat_sppt)
       call mpas_pool_get_array(tend_physics,'stoch_pattern_gg',stoch_pat_gg)
-      stoch_pat_sppt(:,:) = real(domain%dminfo%my_proc_id)
+      ! In the following, is the real() explicit type conversion necessary?
+      ! Fortran should automatically perform implicit type conversion from 
+      ! integer (which is the type of my_proc_id) to whatever the type of
+      ! stoch_pat_sppt is.
+      stoch_pat_sppt(:,:) = real(domain%dminfo%my_proc_id, kind=RKIND)
       block => block%next
     enddo
 
@@ -168,7 +172,7 @@ module mpas_stochastic_physics
     allocate(zk(nVertLevelsP1))
 !    allocate(ak(nVertLevels), bk(nVertLevels))
 
-    call get_zk(zgrid, zk)
+    call get_zk(real(zgrid,kind=kind_phys), zk)
 
     nblks = 0
     block => domain % blocklist
@@ -262,6 +266,8 @@ module mpas_stochastic_physics
 !    call run_stochastic_physics(nVertLevels, ts_ct, blksz, st_pat, stoch_pat_gg, iret)
     if (iret == 0) then ! if pattern is advanced (updated)
       do k = 1, nVertLevels
+        ! The following will involve an implicit type (actually, kind) conversion
+        ! if RKIND and kind_phys are not equivalent.
         stoch_pat_sppt(k,1:nCells) = st_pat(1,1:nCells,k)
       enddo
     endif
@@ -293,7 +299,7 @@ module mpas_stochastic_physics
     character(len=32), intent(in) :: tend_names(num_tends)
     integer, intent(out) :: ierr
 
-    real(kind=kind_phys), dimension(:,:),pointer:: tend_array 
+    real(kind=RKIND), dimension(:,:),pointer:: tend_array 
 
     type(block_type),pointer:: block
     integer :: i, j, k, nblks, pid
@@ -368,8 +374,8 @@ module mpas_stochastic_physics
   end subroutine stochastic_physics_pattern_apply
 
   subroutine apply_pattern(tendency, stoch_pattern)
-    real(kind=kind_phys), dimension(nVertLevels,nCells) :: tendency
-    real(kind=kind_phys), dimension(nVertLevels,nCells) :: stoch_pattern
+    real(kind=RKIND), dimension(nVertLevels,nCells) :: tendency
+    real(kind=RKIND), dimension(nVertLevels,nCells) :: stoch_pattern
 
     tendency = tendency*stoch_pattern
 

--- a/stochy_data_mod.F90
+++ b/stochy_data_mod.F90
@@ -5,7 +5,7 @@ module stochy_data_mod
 
 #ifdef MPAS
  use mpas_pool_routines
- use stoch_nml_rec
+ use stochy_nml_rec
 #endif
 ! set up and initialize stochastic random patterns.
 

--- a/stochy_nml_rec.F90
+++ b/stochy_nml_rec.F90
@@ -8,7 +8,7 @@
    !
    !-----------------------------------------------------------------------
 module stoch_nml_rec
-  use kinddef, only: kind_phys, StrKIND
+  use kinddef, only: kind_phys, RKIND, StrKIND
    implicit none
 
    contains
@@ -43,17 +43,31 @@ module stoch_nml_rec
 
       type(mpas_pool_type) :: configPool
 
-      real (kind=kind_phys), pointer :: config_sppt_1
-      real (kind=kind_phys), pointer :: config_sppt_2
-      real (kind=kind_phys), pointer :: config_sppt_3
-      real (kind=kind_phys), pointer :: config_sppt_tau_1
-      real (kind=kind_phys), pointer :: config_sppt_tau_2
-      real (kind=kind_phys), pointer :: config_sppt_tau_3
-      real (kind=kind_phys), pointer :: config_sppt_lscale_1
-      real (kind=kind_phys), pointer :: config_sppt_lscale_2
-      real (kind=kind_phys), pointer :: config_sppt_lscale_3
-      real (kind=kind_phys), pointer :: config_sppt_hgt_top1
-      real (kind=kind_phys), pointer :: config_sppt_hgt_top2
+! Local variables in this subroutine that will be filled in with values from
+! the MPAS namelist using the mpas_pool_get_config() subroutine (which is a
+! generic function) must have the same types and kinds or lengths as the "value"
+! arguments for the type-specific versions of that function.  For example, the
+! subroutine mpas_pool_get_config_real() that reads in a real value, assumes
+! its "value" argument is a "real (kind=RKIND)" (see file mpas_pool_routines.F
+! in the MPAS-Model code base).  Thus, here, any local real variables passed
+! to mpas_pool_get_config() must also be delcared as "real (kind=RKIND)" because
+! otherwise, the build of MPAS-Model with stochastic_physics will fail.  Similarly,
+! any local character variables must be declared as "character (len=StrKIND)".
+! Logical and integer variables can be declared simply as "logical" and "integer"
+! because that's how the subroutines mpas_pool_get_config_logical() and
+! mpas_pool_get_config_int() in mpas_pool_routines.F declare their "value"
+! arguments.
+      real (kind=RKIND), pointer :: config_sppt_1
+      real (kind=RKIND), pointer :: config_sppt_2
+      real (kind=RKIND), pointer :: config_sppt_3
+      real (kind=RKIND), pointer :: config_sppt_tau_1
+      real (kind=RKIND), pointer :: config_sppt_tau_2
+      real (kind=RKIND), pointer :: config_sppt_tau_3
+      real (kind=RKIND), pointer :: config_sppt_lscale_1
+      real (kind=RKIND), pointer :: config_sppt_lscale_2
+      real (kind=RKIND), pointer :: config_sppt_lscale_3
+      real (kind=RKIND), pointer :: config_sppt_hgt_top1
+      real (kind=RKIND), pointer :: config_sppt_hgt_top2
       logical, pointer :: config_do_sppt
       logical, pointer :: config_sppt_logit
       logical, pointer :: config_sppt_sfclimit
@@ -110,6 +124,15 @@ module stoch_nml_rec
 
       call mpas_pool_get_config(configPool, 'do_skeb', config_do_skeb)
       call mpas_pool_get_config(configPool, 'config_stochini', config_stochini)
+
+! Assign values read in from the MPAS-Model namelist to variables native to
+! the stochastic_physics code.  Note that this may involve conversions from
+! one kind to another because the kinds of the local variables here (e.g.
+! config_sppt_1, which is declared as kind=RKIND, which is single-precision
+! if MPAS-Model is built with -DSINGLE_PRECISION and double otherwise) may
+! not be the same as the kinds of the variables native to the stochastic_physics
+! code (e.g. the real array sppt, which is declared as "real (kind=kind_dbl_prec)",
+! where kind_dbl_prec always represents double-precision).
 
       do_sppt = config_do_sppt
       spptint = config_spptint

--- a/stochy_nml_rec.F90
+++ b/stochy_nml_rec.F90
@@ -8,7 +8,7 @@
    !
    !-----------------------------------------------------------------------
 module stoch_nml_rec
-  use kinddef, only: kind_phys, RKIND, StrKIND
+   use kinddef, only: kind_phys, RKIND, StrKIND
    implicit none
 
    contains
@@ -126,27 +126,25 @@ module stoch_nml_rec
       call mpas_pool_get_config(configPool, 'config_stochini', config_stochini)
 
 ! Assign values read in from the MPAS-Model namelist to variables native to
-! the stochastic_physics code.  Note that this may involve conversions from
-! one kind to another because the kinds of the local variables here (e.g.
-! config_sppt_1, which is declared as kind=RKIND, which is single-precision
-! if MPAS-Model is built with -DSINGLE_PRECISION and double otherwise) may
-! not be the same as the kinds of the variables native to the stochastic_physics
-! code (e.g. the real array sppt, which is declared as "real (kind=kind_dbl_prec)",
-! where kind_dbl_prec always represents double-precision).
-
+! the stochastic_physics code.
       do_sppt = config_do_sppt
-      spptint = config_spptint
-      sppt(1) = config_sppt_1
-      sppt(2) = config_sppt_2
-      sppt(3) = config_sppt_3
 
-      sppt_tau(1) = config_sppt_tau_1
-      sppt_tau(2) = config_sppt_tau_2
-      sppt_tau(3) = config_sppt_tau_3
+! spptint is declared as real/kind_dbl_prec, so convert to that type/kind.
+! Note that config_spptint is declared as an integer.
+      spptint = real(config_spptint, kind=kind_dbl_prec)
 
-      sppt_lscale(1) = config_sppt_lscale_1
-      sppt_lscale(2) = config_sppt_lscale_2
-      sppt_lscale(3) = config_sppt_lscale_3
+! sppt, sppt_tau, and sppt_lscale are declared as real/kind_dbl_prec, so
+! convert to that type/kind.  It is not clear why they aren't defined as
+! kind=kind_phys.
+      sppt(1) = real(config_sppt_1, kind=kind_dbl_prec)
+      sppt(2) = real(config_sppt_2, kind=kind_dbl_prec)
+      sppt(3) = real(config_sppt_3, kind=kind_dbl_prec)
+      sppt_tau(1) = real(config_sppt_tau_1, kind=kind_dbl_prec)
+      sppt_tau(2) = real(config_sppt_tau_2, kind=kind_dbl_prec)
+      sppt_tau(3) = real(config_sppt_tau_3, kind=kind_dbl_prec)
+      sppt_lscale(1) = real(config_sppt_lscale_1, kind=kind_dbl_prec)
+      sppt_lscale(2) = real(config_sppt_lscale_2, kind=kind_dbl_prec)
+      sppt_lscale(3) = real(config_sppt_lscale_3, kind=kind_dbl_prec)
 
       sppt_logit = config_sppt_logit
       sppt_sfclimit = config_sppt_sfclimit
@@ -162,8 +160,11 @@ module stoch_nml_rec
 !      iseed_sppt(2) = config_iseed_sppt2
 !      iseed_sppt(3) = config_iseed_sppt3
 
-      sppt_hgt_top1 = config_sppt_hgt_top1
-      sppt_hgt_top2 = config_sppt_hgt_top2
+! sppt_hgt_top1 and sppt_hgt_top2 are declared as real/kind_dbl_prec, so
+! convert to that type/kind.  It is not clear why they aren't defined as
+! kind=kind_phys.
+      sppt_hgt_top1 = real(config_sppt_hgt_top1, kind=kind_dbl_prec)
+      sppt_hgt_top2 = real(config_sppt_hgt_top2, kind=kind_dbl_prec)
 
       do_skeb = config_do_skeb
       stochini = config_stochini

--- a/stochy_nml_rec.F90
+++ b/stochy_nml_rec.F90
@@ -7,7 +7,7 @@
    !> \date    Oct 2024
    !
    !-----------------------------------------------------------------------
-module stoch_nml_rec
+module stochy_nml_rec
    use kinddef, only: kind_phys, RKIND, StrKIND
    implicit none
 
@@ -225,4 +225,4 @@ module stoch_nml_rec
       return
     end subroutine get_nml_rec
 
-end module stoch_nml_rec
+end module stochy_nml_rec


### PR DESCRIPTION
@dustinswales @NingWang325 @JeffBeck-NOAA This PR is to get over the first set of errors (compile-time errors) to get things working with `make`.  I had to make these adjustments to the kinds to get around errors during building of `stochastic_physics` with the stand-alone `MPAS-Model`.  I've put in comments both in this PR and in the code explaining each (but I'm happy to remove the in-line comments if it's too wordy).

@dustinswales Can you let me know if the automated tests still pass?  Will conversion from `kind_phys` to `RKIND` in a few places cause the tests to fail?

Please let me know what you think.