### PR TITLE
Move tendency names. Add association checks.

### DIFF
--- a/Registry_stoch_physics.xml
+++ b/Registry_stoch_physics.xml
@@ -6,11 +6,6 @@
                      description="logical flag for stochastic physics SPPT"
                      possible_values="logical values"/>
 
-		<nml_option name="config_tend_names_phys" type="character" default_value="none"
-                     units="-"
-                     description="list of stochastic physics tendency names to perturb, seperated by comma"
-                     possible_values="Eight-byte integer in string format"/>
-
                 <nml_option name="do_skeb" type="logical" default_value="false" 
                      units="-"
                      description="logical flag for stochastic physics SKEB"

--- a/Registry_stoch_physics.xml
+++ b/Registry_stoch_physics.xml
@@ -6,6 +6,11 @@
                      description="logical flag for stochastic physics SPPT"
                      possible_values="logical values"/>
 
+		<nml_option name="config_tend_names_phys" type="character" default_value="none"
+                     units="-"
+                     description="list of stochastic physics tendency names to perturb, seperated by comma"
+                     possible_values="rucuten-rucvten-rublten-rvblten"/>
+
                 <nml_option name="do_skeb" type="logical" default_value="false" 
                      units="-"
                      description="logical flag for stochastic physics SKEB"

--- a/Registry_stoch_physics.xml
+++ b/Registry_stoch_physics.xml
@@ -9,7 +9,7 @@
 		<nml_option name="config_tend_names_phys" type="character" default_value="none"
                      units="-"
                      description="list of stochastic physics tendency names to perturb, seperated by comma"
-                     possible_values="rucuten-rucvten-rublten-rvblten"/>
+                     possible_values="Eight-byte integer in string format"/>
 
                 <nml_option name="do_skeb" type="logical" default_value="false" 
                      units="-"

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -313,7 +313,7 @@ module mpas_stochastic_physics
    !-----------------------------------------------------------------------
   subroutine stochastic_physics_pattern_apply(domain, tend_category, ierr)
     type(domain_type),intent(in):: domain
-    character(len=32), intent(in) :: tend_category
+    character(len=4), intent(in) :: tend_category
     integer, intent(out) :: ierr
 
     real(kind=RKIND), dimension(:,:),pointer:: tend_array 

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -99,8 +99,8 @@ module mpas_stochastic_physics
     real(kind=kind_phys):: sppt_amp, dtp
     real(kind=kind_phys), dimension(:), pointer:: zk
     real(kind=kind_phys), dimension(:,:), pointer:: xlon, xlat
-    character(len=256) :: config_tend_names_phys
-    
+    character(len=StrKIND), pointer :: config_tend_names_phys
+
     pid = domain%dminfo%my_proc_id  
     configPool = domain%blocklist%configs
 
@@ -226,7 +226,7 @@ module mpas_stochastic_physics
 
   subroutine parse_tend_names(config_tend_names, tend_names)
       character(len=256), intent(in) :: config_tend_names
-      character(len=32), allocatable, intent(inout) :: tend_names(:)
+      character(len=32), pointer, intent(inout) :: tend_names(:)
 
       allocate(tend_names(4))
       tend_names(1) = "rucuten"

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -226,7 +226,7 @@ module mpas_stochastic_physics
 
   subroutine parse_tend_names(config_tend_names, tend_names)
       character(len=256), intent(in) :: config_tend_names
-      character(len=32), allocatable, intent(inout) :: tend_names
+      character(len=32), allocatable, intent(inout) :: tend_names(:)
 
       allocate(tend_names(4))
       tend_names(1) = "rucuten"

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -99,7 +99,6 @@ module mpas_stochastic_physics
     real(kind=kind_phys):: sppt_amp, dtp
     real(kind=kind_phys), dimension(:), pointer:: zk
     real(kind=kind_phys), dimension(:,:), pointer:: xlon, xlat
-    character(len=StrKIND), pointer :: config_tend_names_phys
 
     pid = domain%dminfo%my_proc_id  
     configPool = domain%blocklist%configs
@@ -118,12 +117,16 @@ module mpas_stochastic_physics
     ! There are two ways to apply the perturbations:
     ! 1) Process level physics tendencies (e.g., Wind components from Convection)
     ! 2) Accumulated state tendencies (e.g., Prognositc dycore tendencies (e.g., tend_rtheta))
-    call mpas_pool_get_config(configPool, 'config_tend_names_phys', config_tend_names_phys)
-    call parse_tend_names(config_tend_names_phys, tend_names_phys)
-
-    allocate(tend_names_prog(1))
-    tend_names_prog(5) = "tend_rtheta_physics"
-    print*,"SWALES config_tend_names_phys = ",config_tend_names_phys
+    ! These tendencies are perturbed, IF SPPT is true, AND they are allocated
+    allocate(tend_names_phys(4))
+    tend_names_phys(1) = "rucuten"
+    tend_names_phys(2) = "rvcuten"
+    tend_names_phys(3) = "rublten"
+    tend_names_phys(4) = "rvblten"
+    allocate(tend_names_prog(2))
+    tend_names_prog(1) = "tend_rtheta_physics"
+    tend_names_prog(2) = "tend_rho_physics"
+      
     call mpas_pool_get_config(configPool, 'config_dt', dt)
     call mpas_pool_get_config(configPool, 'config_spptint', spptint)
 
@@ -224,17 +227,6 @@ module mpas_stochastic_physics
 
   end subroutine stochastic_physics_pattern_init
 
-  subroutine parse_tend_names(config_tend_names, tend_names)
-      character(len=256), intent(in) :: config_tend_names
-      character(len=32), pointer, intent(inout) :: tend_names(:)
-
-      allocate(tend_names(4))
-      tend_names(1) = "rucuten"
-      tend_names(2) = "rvcuten"
-      tend_names(3) = "rublten"
-      tend_names(4) = "rvblten"
-      
-  end subroutine parse_tend_names
    !***********************************************************************
    !
    !  routine stochastic_physics_pattern_adv
@@ -363,37 +355,37 @@ module mpas_stochastic_physics
      select case (trim(tend))
        case ("rucuten")
          call mpas_pool_get_array(tend_physics,'rucuten',tend_array)
-         call apply_pattern(tend_array, stoch_pat_sppt)
+         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
 #ifdef STOCH_PHYS_DIAG
          if (pid == 0) print*, 'apply perturbation pattern to rucuten'
 #endif
        case ("rvcuten")
          call mpas_pool_get_array(tend_physics,'rvcuten',tend_array)
-         call apply_pattern(tend_array, stoch_pat_sppt)
+         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
 #ifdef STOCH_PHYS_DIAG
          if (pid == 0) print*, 'apply perturbation pattern to rvcuten'
 #endif
        case ("rublten")
          call mpas_pool_get_array(tend_physics,'rublten',tend_array)
-         call apply_pattern(tend_array, stoch_pat_sppt)
+         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
 #ifdef STOCH_PHYS_DIAG
          if (pid == 0) print*, 'apply perturbation pattern to rublten'
 #endif
        case ("rvblten")
          call mpas_pool_get_array(tend_physics,'rvblten',tend_array)
-         call apply_pattern(tend_array, stoch_pat_sppt)
+         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
 #ifdef STOCH_PHYS_DIAG
          if (pid == 0) print*, 'apply perturbation pattern to rvblten'
 #endif
        case ("tend_rtheta_physics")
          call mpas_pool_get_array(tend_physics,'tend_rtheta_physics',tend_array)
-         call apply_pattern(tend_array, stoch_pat_sppt)
+         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
 #ifdef STOCH_PHYS_DIAG
          if (pid == 0) print*, 'apply perturbation pattern to rtheta'
 #endif
        case ("tend_rho_physics")
          call mpas_pool_get_array(tend_physics,'tend_rho_physics',tend_array)
-         call apply_pattern(tend_array, stoch_pat_sppt)
+         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
 #ifdef STOCH_PHYS_DIAG
          if (pid == 0) print*, 'apply perturbation pattern to rho'
 #endif

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -116,7 +116,7 @@ module mpas_stochastic_physics
     ! Set up tendencies for SPPT from namelist.
     ! There are two ways to apply the perturbations:
     ! 1) Process level physics tendencies (e.g., Wind components from Convection)
-    ! 2) Accumulated state tendencies (e.g., Prognositc dycore tendencies (e.g., tend_rtheta))
+    ! 2) Accumulated state tendencies (e.g., Prognositc physics tendencies (e.g., tend_rtheta))
     ! These tendencies are perturbed, IF SPPT is true, AND they are allocated
     allocate(tend_names_phys(4))
     tend_names_phys(1) = "rucuten"

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -49,8 +49,8 @@ module mpas_stochastic_physics
   real(kind=RKIND), pointer :: sppt_tau_1, sppt_tau_2, sppt_tau_3
   real(kind=RKIND), pointer :: sppt_lscale_1, sppt_lscale_2, sppt_lscale_3
   integer, pointer :: spptint
-  character(len=32), allocatable, dimension(:) :: tend_names_phys
-  character(len=32), allocatable, dimension(:) :: tend_names_prog
+  character(len=32), pointer, dimension(:) :: tend_names_phys
+  character(len=32), pointer, dimension(:) :: tend_names_prog
 
   integer, save :: nblks
 
@@ -119,14 +119,11 @@ module mpas_stochastic_physics
     ! 1) Process level physics tendencies (e.g., Wind components from Convection)
     ! 2) Accumulated state tendencies (e.g., Prognositc dycore tendencies (e.g., tend_rtheta))
     call mpas_pool_get_config(configPool, 'config_tend_names_phys', config_tend_names_phys)
-    allocate(tend_names_phys(4))
+    call parse_tend_names(config_tend_names_phys, tend_names_phys)
+
     allocate(tend_names_prog(1))
-    tend_names_phys(1) = "rucuten"
-    tend_names_phys(2) = "rvcuten"
-    tend_names_phys(3) = "rublten"
-    tend_names_phys(4) = "rvblten"
     tend_names_prog(5) = "tend_rtheta_physics"
-    print("SWALES config_tend_names_phys = ",config_tend_names_phys)
+    print*,"SWALES config_tend_names_phys = ",config_tend_names_phys
     call mpas_pool_get_config(configPool, 'config_dt', dt)
     call mpas_pool_get_config(configPool, 'config_spptint', spptint)
 
@@ -227,6 +224,17 @@ module mpas_stochastic_physics
 
   end subroutine stochastic_physics_pattern_init
 
+  subroutine parse_tend_names(config_tend_names, tend_names)
+      character(len=256), intent(in) :: config_tend_names_phys
+      character(len=32), allocatable, intent(inout) :: tend_names
+
+      allocate(tend_names(4))
+      tend_names(1) = "rucuten"
+      tend_names(2) = "rvcuten"
+      tend_names(3) = "rublten"
+      tend_names(4) = "rvblten"
+      
+  end subroutine parse_tend_names
    !***********************************************************************
    !
    !  routine stochastic_physics_pattern_adv

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -49,6 +49,8 @@ module mpas_stochastic_physics
   real(kind=RKIND), pointer :: sppt_tau_1, sppt_tau_2, sppt_tau_3
   real(kind=RKIND), pointer :: sppt_lscale_1, sppt_lscale_2, sppt_lscale_3
   integer, pointer :: spptint
+  character(len=32), allocatable, dimension(:) :: tend_names_phys
+  character(len=32), allocatable, dimension(:) :: tend_names_prog
 
   integer, save :: nblks
 
@@ -110,6 +112,18 @@ module mpas_stochastic_physics
       call mpas_log_write('    do_sppt is false, do not perturb physics tendencies.')
       return
     endif
+
+    ! Set up tendencies for SPPT from namelist.
+    ! There are two ways to apply the perturbations:
+    ! 1) Process level physics tendencies (e.g., Wind components from Convection)
+    ! 2) Accumulated state tendencies (e.g., Prognositc dycore tendencies (e.g., tend_rtheta))
+    allocate(tend_names_phys(4))
+    allocate(tend_names_prog(1))
+    tend_names_phys(1) = "rucuten"
+    tend_names_phys(2) = "rvcuten"
+    tend_names_phys(3) = "rublten"
+    tend_names_phys(4) = "rvblten"
+    tend_names_prog(5) = "tend_rtheta_physics"
 
     call mpas_pool_get_config(configPool, 'config_dt', dt)
     call mpas_pool_get_config(configPool, 'config_spptint', spptint)
@@ -295,19 +309,26 @@ module mpas_stochastic_physics
    !>  from both PBL and convection schemes, at the cell centers.
    !
    !-----------------------------------------------------------------------
-  subroutine stochastic_physics_pattern_apply(domain, num_tends, tend_names, ierr)
+  subroutine stochastic_physics_pattern_apply(domain, tend_category, ierr)
     type(domain_type),intent(in):: domain
-    integer, intent(in) :: num_tends
-    character(len=32), intent(in) :: tend_names(num_tends)
+    character(len=32), intent(in) :: tend_category
     integer, intent(out) :: ierr
 
     real(kind=RKIND), dimension(:,:),pointer:: tend_array 
-
+    character(len=32), dimension(:) :: pointer :: tend_names
     type(block_type),pointer:: block
     integer :: i, j, k, nblks, pid
     character(len=32) :: tend
      
-    pid = domain%dminfo%my_proc_id  
+    pid = domain%dminfo%my_proc_id
+      
+    if (trim(tend_category) == 'phys') then
+       tend_names => tend_names_phys
+    else if (trim(tend_category) == 'prog') then
+       tend_names => tend_names_prog
+    else
+       stop "Invalid tend_category: tend_category ="//trim(tend_category)
+    end if
 
 #ifdef STOCH_PHYS_DIAG
     if (pid == 0) print*, 'Enter stochastic_physics_pattern_apply, pid = ', pid
@@ -326,7 +347,7 @@ module mpas_stochastic_physics
 
  ! retrieve the specified tendencies that needs to be perturbed and
  ! apply the patterns (at all levels) to the tendency      
-   do i = 1, num_tends
+   do i = 1, size(tend_names)
      tend = tend_names(i)
 !     print*, "tendency from physics parameterization to be perturbed:", trim(tend)
      select case (trim(tend))
@@ -371,6 +392,7 @@ module mpas_stochastic_physics
      end select
    enddo
 
+   nullify(tend_names)
    ierr = 0
 
   end subroutine stochastic_physics_pattern_apply

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -225,7 +225,7 @@ module mpas_stochastic_physics
   end subroutine stochastic_physics_pattern_init
 
   subroutine parse_tend_names(config_tend_names, tend_names)
-      character(len=256), intent(in) :: config_tend_names_phys
+      character(len=256), intent(in) :: config_tend_names
       character(len=32), allocatable, intent(inout) :: tend_names
 
       allocate(tend_names(4))

--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -99,6 +99,7 @@ module mpas_stochastic_physics
     real(kind=kind_phys):: sppt_amp, dtp
     real(kind=kind_phys), dimension(:), pointer:: zk
     real(kind=kind_phys), dimension(:,:), pointer:: xlon, xlat
+    character(len=256) :: config_tend_names_phys
     
     pid = domain%dminfo%my_proc_id  
     configPool = domain%blocklist%configs
@@ -117,6 +118,7 @@ module mpas_stochastic_physics
     ! There are two ways to apply the perturbations:
     ! 1) Process level physics tendencies (e.g., Wind components from Convection)
     ! 2) Accumulated state tendencies (e.g., Prognositc dycore tendencies (e.g., tend_rtheta))
+    call mpas_pool_get_config(configPool, 'config_tend_names_phys', config_tend_names_phys)
     allocate(tend_names_phys(4))
     allocate(tend_names_prog(1))
     tend_names_phys(1) = "rucuten"
@@ -124,7 +126,7 @@ module mpas_stochastic_physics
     tend_names_phys(3) = "rublten"
     tend_names_phys(4) = "rvblten"
     tend_names_prog(5) = "tend_rtheta_physics"
-
+    print("SWALES config_tend_names_phys = ",config_tend_names_phys)
     call mpas_pool_get_config(configPool, 'config_dt', dt)
     call mpas_pool_get_config(configPool, 'config_spptint', spptint)
 
@@ -315,7 +317,7 @@ module mpas_stochastic_physics
     integer, intent(out) :: ierr
 
     real(kind=RKIND), dimension(:,:),pointer:: tend_array 
-    character(len=32), dimension(:) :: pointer :: tend_names
+    character(len=32), dimension(:), pointer :: tend_names
     type(block_type),pointer:: block
     integer :: i, j, k, nblks, pid
     character(len=32) :: tend


### PR DESCRIPTION
### Description
- This moved the defining of the fields to be perturbed by SPPT from MPAS-A into the Stochastic_physics initialization step here.
- Partition tendency list into "process (moist) physics" and "accumulated (dry) physics" tendencies.
- Only perturb tendencies if they are active within the host (e.g. if associated)