### PR TITLE
Remove redundant select-case statement that checks for tendency names…

### DIFF
--- a/mpas_stochastic_physics.F
+++ b/mpas_stochastic_physics.F
@@ -125,7 +125,11 @@ module mpas_stochastic_physics
     tend_names_phys(4) = "rvblten"
     allocate(tend_names_prog(2))
     tend_names_prog(1) = "tend_rtheta_physics"
-    tend_names_prog(2) = "tend_rho_physics"
+    ! We usually don't perturb "tend_rho_physics" because rho is already included in
+    ! "rtheta", which is being perturbed.  But we will be perturbing "tend_ru_physics".
+    ! (via SKEB).  So exclude "tend_rho_physics" and instead include "tend_u_physics".
+    !tend_names_prog(2) = "tend_rho_physics"
+    tend_names_prog(2) = "tend_u_physics"
       
     call mpas_pool_get_config(configPool, 'config_dt', dt)
     call mpas_pool_get_config(configPool, 'config_spptint', spptint)
@@ -351,47 +355,15 @@ module mpas_stochastic_physics
  ! apply the patterns (at all levels) to the tendency      
    do i = 1, size(tend_names)
      tend = tend_names(i)
-!     print*, "tendency from physics parameterization to be perturbed:", trim(tend)
-     select case (trim(tend))
-       case ("rucuten")
-         call mpas_pool_get_array(tend_physics,'rucuten',tend_array)
-         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
+     call mpas_pool_get_array(tend_physics, trim(tend), tend_array)
+     if (associated(tend_array)) then
 #ifdef STOCH_PHYS_DIAG
-         if (pid == 0) print*, 'apply perturbation pattern to rucuten'
+       if (pid == 0) print*, 'applying perturbation pattern to ', trim(tend)
 #endif
-       case ("rvcuten")
-         call mpas_pool_get_array(tend_physics,'rvcuten',tend_array)
-         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
-#ifdef STOCH_PHYS_DIAG
-         if (pid == 0) print*, 'apply perturbation pattern to rvcuten'
-#endif
-       case ("rublten")
-         call mpas_pool_get_array(tend_physics,'rublten',tend_array)
-         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
-#ifdef STOCH_PHYS_DIAG
-         if (pid == 0) print*, 'apply perturbation pattern to rublten'
-#endif
-       case ("rvblten")
-         call mpas_pool_get_array(tend_physics,'rvblten',tend_array)
-         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
-#ifdef STOCH_PHYS_DIAG
-         if (pid == 0) print*, 'apply perturbation pattern to rvblten'
-#endif
-       case ("tend_rtheta_physics")
-         call mpas_pool_get_array(tend_physics,'tend_rtheta_physics',tend_array)
-         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
-#ifdef STOCH_PHYS_DIAG
-         if (pid == 0) print*, 'apply perturbation pattern to rtheta'
-#endif
-       case ("tend_rho_physics")
-         call mpas_pool_get_array(tend_physics,'tend_rho_physics',tend_array)
-         if (associated(tend_array)) call apply_pattern(tend_array, stoch_pat_sppt)
-#ifdef STOCH_PHYS_DIAG
-         if (pid == 0) print*, 'apply perturbation pattern to rho'
-#endif
-       case default 
-         print*, "The specified tendency is unknown and not perturbed." 
-     end select
+       call apply_pattern(tend_array, stoch_pat_sppt)
+     else
+       call mpas_log_write('stochastic_physics_pattern_apply: tendency "' // trim(tend) // '" not allocated; skipping perturbation.', messageType=MPAS_LOG_WARN)
+     endif
    enddo
 
    nullify(tend_names)


### PR DESCRIPTION
Tweaks to the tendency perturbation procedure for MPAS:

1. If perturbing prognostic tendencies (instead of individual physics tendencies):
    - Don't perturb the density (rho) tendency `"tend_rho_physics"` since rho is already perturbed as part of `"tend_rtheta_physics"` (which is the tendency for the prognostic equation for rho*theta).
    - Do perturb the tendency for u (i.e. `"tend_u_physics".`), which in MPAS is the velocity component normal to each cell face.
2. Remove redundant select-case statement that checks for tendency names.
 